### PR TITLE
Fix typos in README files

### DIFF
--- a/FHIR/FHIREventProcessor/readme.md
+++ b/FHIR/FHIREventProcessor/readme.md
@@ -3,7 +3,7 @@
 FHIR Event Processor is an Azure Function App solution that provides the following services for ingesting FHIR Resources into the FHIR Server:
  + Import and process valid HL7 bundles and persist them into a FHIR Compliant store.
  + Provides a secure proxy a connection to a destination FHIR Server without exposing credentials
- + Publish sucessful FHIR Server CRUD events to an event hub for topic subscribers to use in event driven workflows
+ + Publish successful FHIR Server CRUD events to an event hub for topic subscribers to use in event driven workflows
 
 # Architecture Overview
 ![hl7ingest Arch](arch.png)

--- a/FHIR/FHIRExportQuickstart/README.md
+++ b/FHIR/FHIRExportQuickstart/README.md
@@ -37,7 +37,7 @@ Before deploying make sure you have:
     git clone https://github.com/Microsoft/health-architectures
     ```
 
-2. navigate health-architectures/FHIRExportQuickStart and open the arm_template_parameters.json file in your perference json editor. Notepad works.
+2. Navigate to health-architectures/FHIRExportQuickStart and open the arm_template_parameters.json file in your preferred JSON editor. Notepad works.
 
     ```json
     {
@@ -59,20 +59,20 @@ Before deploying make sure you have:
         "fhirauth-tenantid": {
             "value": "",
             "metadata": {
-                "description": "Supply only if fhir authenication and the deployment subscription are not in the same tenant. If you are unsure leave NULL or remove segment"
+                "description": "Supply only if fhir authentication and the deployment subscription are not in the same tenant. If you are unsure leave NULL or remove segment"
             }
         }
     }
     }
     ```
 
-3. Fill out the parameter values with your inforamtion. Save & Close the file.
+3. Fill out the parameter values with your information. Save & Close the file.
 
 #### Log in to Azure using PowerShell
 
 1. Launch **PowerShell** on your machine. Keep PowerShell open until the end of this tutorial. If you close and reopen, you may need to run these commands again.
 
-2. Make sure PowerShell is in the correct directiory
+2. Make sure PowerShell is in the correct directory
 
    ```powershell
    cd health-architectures/FHIRExportQuickStart
@@ -102,10 +102,10 @@ Before deploying make sure you have:
     $Name = "<NAME HERE>", #default is fhirexport
     $Location = "<LOCATION HERE>" #default is eastus
 
-    ./ deployFHIRExport.ps1 -EnvironmentName $Name -EnvironmentLocation $Location
+    ./deployFHIRExport.ps1 -EnvironmentName $Name -EnvironmentLocation $Location
     ```
 
-7. When the PowerShell is finished you should have a LogicApp ready to run your export. You can manually trigger in the Azure Portal or but using this command.
+7. When the PowerShell is finished you should have a LogicApp ready to run your export. You can manually trigger in the Azure Portal or by using this command.
 
 ```powershell
 Start-AzLogicApp

--- a/FHIR/FHIRExportwithAnonymization/README.md
+++ b/FHIR/FHIRExportwithAnonymization/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The FHIR Export with Anonymization is a template for creating an automated pipeling to process the bulk export for FHIR using Azure tools. The goal of the template is to enable quick and continuous creation of research datasets while applying HIPAA safe harbor rules.
+The FHIR Export with Anonymization is a template for creating an automated pipeline to process the bulk export for FHIR using Azure tools. The goal of the template is to enable quick and continuous creation of research datasets while applying HIPAA safe harbor rules.
 
 The template connects multiple tools from the Microsoft Health Cloud and Data Team together into an automated solution. The two main components are:
 
@@ -17,18 +17,18 @@ The FHIR Export with Anonymization follows the architecture and steps below.
 
 1. Timer triggers Logic App - 1:00 AM UTC is the default
 2. Logic App calls FHIR service with GET $export
-3. The FHIR service pushs bulk export to preset storage location
+3. The FHIR service pushes bulk export to preset storage location
 4. Logic App runs an Until loop waiting for $export operation to complete
 5. Logic App sends the $export storage location information to Azure Data Factory
 6. Azure Data Factory calls Azure Batch with the storage location information
 7. Azure Batch performs the deidentification with the FHIR Tools for Anonymization
 8. Azure Batch and Azure Data Factory put the deidentified data in a new output location (Azure Data Lake Gen 2)
 
-The Big Data tools shown in the architecture are a representatoin of what you can use. They are not included in the template and therefore will not be deployed.
+The Big Data tools shown in the architecture are a representation of what you can use. They are not included in the template and therefore will not be deployed.
 
 The Azure Logic App loops on a 5 minute time checking for the Bulk Export to finish. If the export is not complete the Logic App will wait 5 minutes then check again. The frequency is adjustable inside the Azure Logic App.
 
-Note: The template does not goes as far as applying networking rules. You may revise the template to include the rules for your environment, or manually adjust them after deployment.
+Note: The template does not go as far as applying networking rules. You may revise the template to include the rules for your environment, or manually adjust them after deployment.
 
 ## Prerequisites
 
@@ -52,7 +52,7 @@ Before deploying the pipeline, make sure you have:
     git clone https://github.com/Microsoft/health-architectures
     ```
 
-2. Navigate health-architectures/FHIR/FHIRExportwithAnonymization and open the ./Assets/arm_template_parameters.json file in your perferred json editor. Replace FHIR URL, client id, client secret, tenant id and storage account with yours.
+2. Navigate to health-architectures/FHIR/FHIRExportwithAnonymization and open the ./Assets/arm_template_parameters.json file in your preferred JSON editor. Replace FHIR URL, client id, client secret, tenant id and storage account with yours.
 
 ```json
 {
@@ -75,7 +75,7 @@ Before deploying the pipeline, make sure you have:
         "fhirauth-tenantid": {
             "value": "",
             "metadata": {
-                "description": "Supply only if FHIR authenication and the deployment subscription are not in the same tenant. If you are unsure leave "" or remove entire segment"
+                "description": "Supply only if FHIR authentication and the deployment subscription are not in the same tenant. If you are unsure leave "" or remove entire segment"
             }
         },
         "IntegrationStorageAccount":{
@@ -110,7 +110,7 @@ The FHIR Export with Anonymization uses the default settings in the Anonymizatio
 
 1. Launch **PowerShell** on your machine. Keep PowerShell open until the end of this tutorial. If you close and reopen, you may need to run these commands again.
 
-2. Make sure PowerShell is run in the correct directiory
+2. Make sure PowerShell is run in the correct directory
 
    ```powershell
    cd health-architectures/FHIRExportQuickStart
@@ -148,7 +148,7 @@ This deployment process may take 5 minutes or more to complete.
 Common errors on deployment include:
 
 - Azure Batch not enabled in the subscription
-- Azure Batch already deployed the max number of time in a subscription
+- Azure Batch already deployed the max number of times in a subscription
 
 ## Post Deployment
 

--- a/FHIR/FHIRProxy/readme.md
+++ b/FHIR/FHIRProxy/readme.md
@@ -1,7 +1,7 @@
 # Secure FHIR Proxy
 
 Secure FHIR Proxy is an Azure Function based solution to act as an intelligent FHIR reverse proxy.
-It is integrated with Azure Active Directory to provide Role based access control.  This solution contains the following examples:
+It is integrated with Azure Active Directory (AAD) to provide Role based access control.  This solution contains the following examples:
  + ProxyBase - A generic FHIR Proxy with no business logic validation and only authentication verification. You can use this sample to build your own business purpose driven proxy to perform any pre processing and post processing tasks for FHIR server calls.
  + ParticipantAccess - A sample FHIR Proxy based on ProxyBase that will filter returned patient based resources to only include Patients where you are the patient or are a "Practitioner of Record" (e.g. in a participant role and are part of the patient care team) Note: this only filters patient based resources
  + SecureLink - A administration function that links AAD Principals in roles for the FHIR server with corresponding FHIR Resources to establish a map between AAD Role Identity and FHIR
@@ -33,7 +33,7 @@ Please note you should deploy this proxy into a tenant that you control Applicat
 13. Congratulations you now have a Secure FHIR Proxy instance with authentication running. You can now configure Authorized Access.
 
 ## Configuring Authorization Access Roles for Users
-At a minimum users must be placed in one or more FHIR Access roles in order to access the FHIR Server. The Access roles are Administrator, Resource Reader and Resource Writer 
+At a minimum, users must be placed in one or more FHIR Access roles in order to access the FHIR Server. The Access roles are Administrator, Resource Reader and Resource Writer
 1. [Login to Azure Portal](https://portal.azure.com) _Note: If you have multiple tenants make sure you switch to the directory that contains the Secure FHIR Proxy_
 2. [Access the Azure Active Directory Enterprise Application Blade](https://ms.portal.azure.com/#blade/Microsoft_AAD_IAM/StartboardApplicationsMenuBlade/AllApps/menuId/)
 3. Change the Application Type Drop Down to All Applications and click the Apply button
@@ -54,23 +54,23 @@ At a minimum users must be placed in one or more FHIR Access roles in order to a
 11. Select and/or Search and Select registered users/guests that you want to assign the selected role too.
 12. When all users desired have been selected click the select button at the bottom of the panel.
 13. Click the Assign button.
-14. Congratulations the select users have been assigned the access role and can now perform allowed operations against the FHIR Server
+14. Congratulations! The selected users have been assigned the access role and can now perform allowed operations against the FHIR Server
 
 # ProxyBase Endpoint
 This endpoint will by default only enforce access roles granted to users/applications. You can GET/POST any FHIR compliant request/query
-For example to see conformance statement for the FHIR Server, use your browser and access the following endpoint:</br>
+For example to see the conformance statement for the FHIR Server, use your browser and access the following endpoint:</br>
 ```https://<secure proxy url from above>/api/fhir/metadata```
 
 _Note: Individual endpoints can be disabled by disabling the corresponding Function in the Secure FHIR Proxy Function App via the Azure Portal_</br>
 _Note: You will need to login as a user in a FHIR Reader and/or FHIR Administrative role to view._
  
 # Participant Endpoint
-This endpoint is a further extended example of the ProxyBase endpoint it will filter returned patient based resources to only include Patients where you are the patient owner of the medical record or are a "Practitioner of Record" (e.g. in a participant role and are part of the patient care team, listed as a practitioner participant in an Encounter resource or a general practitioner for the Patient) The process is depicted in the diagram below:
+This endpoint is a further extended example of the ProxyBase endpoint it will filter returned patient based resources to only include Patients where you are the patient owner of the medical record or are a "Practitioner of Record" (e.g. in a participant role and are part of the patient care team, listed as a practitioner participant in an Encounter resource or a general practitioner for the Patient). The process is depicted in the diagram below:
 ## How the participant endpoint works
 ![F H I R Proxy Seq](FHIRProxy_Seq.png)
 
 ## Configuring Participant Authorization Roles for Users
-At a minimum users must be placed in one or more FHIR Participant roles in order to appropriately filter results from tbe FHIR Server. The Access roles are Patient, Practitioner and RelatedPerson. _Note:The user must also be in an appropriate Access role defined above_
+At a minimum, users must be placed in one or more FHIR Participant roles in order to appropriately filter results from tbe FHIR Server. The Access roles are Patient, Practitioner and RelatedPerson. _Note:The user must also be in an appropriate Access role defined above_
 1. [Login to Azure Portal](https://portal.azure.com) _Note: If you have multiple tenants make sure you switch to the directory that contains the Secure FHIR Proxy_
 2. [Access the Azure Active Directory Enterprise Application Blade](https://ms.portal.azure.com/#blade/Microsoft_AAD_IAM/StartboardApplicationsMenuBlade/AllApps/menuId/)
 3. Change the Application Type Drop Down to All Applications and click the Apply button
@@ -90,7 +90,7 @@ At a minimum users must be placed in one or more FHIR Participant roles in order
 11. Select and/or Search and Select registered users/guests that you want to assign the selected role too.
 12. When all users desired have been selected click the select button at the bottom of the panel.
 13. Click the Assign button.
-14. Congratulations the select users have been assigned the participant role and can now be linked to FHIR Resources
+14. Congratulations! The selected users have been assigned the participant role and can now be linked to FHIR Resources
 
 ## Linking Users in Participant Roles to FHIR Resources
 1. Make sure you have configured Participant Authorization Roles for users
@@ -112,14 +112,14 @@ At a minimum users must be placed in one or more FHIR Participant roles in order
     For example: ```somedoctor@sometenant.onmicrosoft.com```
  4. Now you can link the FHIR Resource to the user principal name by entering the following URL in your browser:
  
-    ```https://<your fhir proxy url>/api/manage/link/<ResourceName>/<ResourceID>?name=<user prinicipal name>``` 
+    ```https://<your fhir proxy url>/api/manage/link/<ResourceName>/<ResourceID>?name=<user principal name>```
 
-    For example to connect Dr. Mickey in my AAD tenant principal who’s user name is mickey@myaad.onmicrosoft.com to the FHIR Practitioner Resource Id 3bdaac8f-5c8e-499d-b906-aab31633337d you would enter the following URL:
+    For example to connect Dr. Mickey in my AAD tenant principal whose user name is mickey@myaad.onmicrosoft.com to the FHIR Practitioner Resource Id 3bdaac8f-5c8e-499d-b906-aab31633337d you would enter the following URL:
     ```https://<your fhir proxy url>/api/manage/link/Practitioner/3bdaac8f-5c8e-499d-b906-aab31633337d?name=mickey@myaad.onmicrosoft.com```
      
     _Note: You will need to login as a user in a FHIR Administrative role to perform the assignment_
 
-5.  Your done the principal user is now connected in role to the FHIR resource.
+5.  You are done! The principal user is now connected in role to the FHIR resource.
 
 ## Contributing
 

--- a/IoMT/IoMTReferenceArchitecture.md
+++ b/IoMT/IoMTReferenceArchitecture.md
@@ -29,7 +29,7 @@ The 4 line colors show the different parts of the data journey.
 6.	Normalized ungrouped data stream sent to Azure Function (ML Input). 
 7.	Azure Function (ML Input) requests Patient resource to merge with IoMT payload.
 8.	IoMT payload with PHI is sent to Event Hub for distribution to Machine Learning compute and storage.
-9.	PHI IoMT payload is sent to Azure Data Lake Storage Gen 2 for scoring oberservation over longer time windows. 
+9.	PHI IoMT payload is sent to Azure Data Lake Storage Gen 2 for scoring observation over longer time windows.
 10.	PHI IoMT payload is sent to Azure DataBricks for windowing, data fitting, and data scoring.
 11.	The Azure DataBricks requests additional patient data from data lake as needed.
     a.	Azure DataBricks also sends a copy of the scored data to the data lake.

--- a/IoMT/IoMTandTeamsPatientApp.md
+++ b/IoMT/IoMTandTeamsPatientApp.md
@@ -1,8 +1,8 @@
 ### IoMT Connector for Azure and Microsoft Teams Patient App
 
 When combining the [IoMT Connector for Azure](https://github.com/microsoft/iomt-fhir), Azure API for FHIR, 
-and Microsoft Teams customers can enable multiple care solutions. Below is the conceptual architecture for enabling IoMT connector, FHIR and Microsoft Teams Patient App. We can even embed Power BI Dashbaords inside 
-the Microsoft Teams client. For more information on embeding Power BI in Microsoft Team visit [here.](https://powerbi.microsoft.com/en-us/blog/power-bi-teams-up-with-microsoft-teams/)
+and Microsoft Teams customers can enable multiple care solutions. Below is the conceptual architecture for enabling IoMT connector, FHIR and Microsoft Teams Patient App. We can even embed Power BI Dashboards inside
+the Microsoft Teams client. For more information on embedding Power BI in Microsoft Team visit [here.](https://powerbi.microsoft.com/en-us/blog/power-bi-teams-up-with-microsoft-teams/)
 
 #### IoMT Connector and Team Reference Architecture 
 

--- a/IoMT/README.md
+++ b/IoMT/README.md
@@ -1,9 +1,9 @@
 ## IoMT FHIR Solutions Getting Started
 
 The IoMT FHIR Connector for Azure enables rapid deployments of IoT to FHIR projects. Enclosed is a set of solutions
-for getting started on a varity of IoMT projects. 
+for getting started on a variety of IoMT projects.
 
-If you are not familar with the Microsoft IoMT FHIR Connector for Azure please visit - https://azure.microsoft.com/en-us/blog/accelerate-iomt-on-fhir-with-new-microsoft-oss-connector/
+If you are not familiar with the Microsoft IoMT FHIR Connector for Azure please visit - https://azure.microsoft.com/en-us/blog/accelerate-iomt-on-fhir-with-new-microsoft-oss-connector/
 
 Here are some architectures to assist with end to end solutioning of your IoMT projects.
 


### PR DESCRIPTION
I recently read through all of these super useful reference architectures and noticed a few typos in the README files, so submitting a pull request to fix them.