### PR TITLE
Remove jq dependency in FHIR Proxy setup scripts

### DIFF
--- a/FHIR/FHIRProxy/deployfhirproxy.bash
+++ b/FHIR/FHIRProxy/deployfhirproxy.bash
@@ -188,10 +188,10 @@ echo "Starting Secure FHIR Proxy deployment..."
 		echo "Creating Secure FHIR Proxy Function App ["$faname"]..."
 		fahost=$(az functionapp create --name $faname --storage-account $deployprefix$storageAccountNameSuffix  --plan $deployprefix$serviceplanSuffix  --resource-group $resourceGroupName --runtime dotnet --os-type Windows --query defaultHostName --output tsv)
 		echo "Creating Service Principal for AAD Auth"
-		stepresult=$(az ad sp create-for-rbac -n "https://"$fahost)
-		spappid=$(echo $stepresult | jq -r '.appId')
-		sptenant=$(echo $stepresult | jq -r '.tenant')
-		spsecret=$(echo $stepresult | jq -r '.password')
+		stepresult=$(az ad sp create-for-rbac --query '[appId,tenant,password]' -o tsv -n "https://"$fahost)
+		spappid=$(echo $stepresult | cut -f1 -d' ')
+		sptenant=$(echo $stepresult | cut -f2 -d' ')
+		spsecret=$(echo $stepresult | cut -f3 -d' ')
 		spreplyurls="https://"$fahost"/.auth/login/aad/callback"
 		tokeniss="https://sts.windows.net/"$sptenant
 		echo "Adding Sign-in User Read Permission on Graph API..."

--- a/FHIR/FHIRProxy/readme.md
+++ b/FHIR/FHIRProxy/readme.md
@@ -46,12 +46,11 @@ Please note you should deploy this proxy into a tenant that you control Applicat
    + The Audience/Resource for the FHIR Server/Service Client typically https://<I>[yourfhirservername]</I>.azurehealthcareapis.com for Azure API for FHIR
 6. [If you are running Windows 10 make sure you have enabled Windows Linux Subsystem](https://code.visualstudio.com/remote-tutorials/wsl/enable-wsl) and [Installed a Linux Distribution](https://code.visualstudio.com/remote-tutorials/wsl/install-linux)
 7. [Install Azure CLI 2.0 on Linux based System or Windows Linux Subsystem](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest)
-8. [Install jq for your environment](https://stedolan.github.io/jq/download/)
-9. [Download/Clone this repo](https://github.com/microsoft/health-architectures)
-10. Open a bash shell into the Azure CLI 2.0 environment
-11. Switch to the FHIR/FHIRproxy subdirectory of this repo ```cd FHIR/FHIRProxy```
-12. Run the ```deployfhirproxy.bash``` script and follow the prompts
-13. Congratulations you now have a Secure FHIR Proxy instance with authentication running. You can now add users/groups for authorized access (see below)
+8. [Download/Clone this repo](https://github.com/microsoft/health-architectures)
+9. Open a bash shell into the Azure CLI 2.0 environment
+10. Switch to the FHIR/FHIRproxy subdirectory of this repo ```cd FHIR/FHIRProxy```
+11. Run the ```deployfhirproxy.bash``` script and follow the prompts
+12. Congratulations you now have a Secure FHIR Proxy instance with authentication running. You can now add users/groups for authorized access (see below)
 
 # Proxy Endpoint
 The new endpoint for your FHIR Server should now be: ```https://<secure proxy url from above>/api/fhirproxy```. You can use any supported FHIR HTTP verb and any FHIR compliant request/query


### PR DESCRIPTION
Currently the FHIR Proxy setup scripts depend on the external tool `jq` to extract specific items from JSON payloads returned by the Azure CLI.

However, the Azure CLI supports querying the JSON responses natively via [--query](https://docs.microsoft.com/en-us/cli/azure/query-azure-cli). As such, this change updates the scripts to use `--query` instead of `jq` which removes an external tool dependency and therewith makes the scripts more self-contained and easier to run in the user's environment.

Here's an example Bash session that demonstrates the approach without `jq`:

![Screenshot showing processing of Azure CLI response without jq](https://user-images.githubusercontent.com/1086421/86808543-f6dbce00-c048-11ea-859b-36c537aea5ad.png)
