### PR TITLE
Fhir export with anonymization readme update and config adjustments

### DIFF
--- a/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part1.json
+++ b/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part1.json
@@ -27,7 +27,7 @@
             "defaultValue": "STANDARD_D4_V3",
             "type": "string"
         },
-        "IntegrationStorageAccount":{
+        "IntegrationStorageAccount": {
             "type": "string"
         }
     },
@@ -47,15 +47,16 @@
     },
     "resources": [
         {
+            "condition": "[equals(variables('storageAccountName'),concat(variables('resourceGroup'),'stg'))]",
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
             "name": "[variables('storageAccountName')]",
             "location": "[variables('rgLocation')]",
             "tags": {
-            "HealthArchitestures": "FHIRToDEIDPipeline"
+                "HealthArchitestures": "FHIRToDEIDPipeline"
             },
             "sku": {
-                "name": "Standard_ZRS",
+                "name": "Standard_LRS",
                 "tier": "Standard"
             },
             "kind": "StorageV2",
@@ -80,6 +81,7 @@
             }
         },
         {
+            "condition": "[equals(variables('storageAccountName'),concat(variables('resourceGroup'),'stg'))]",
             "type": "Microsoft.Storage/storageAccounts/blobServices",
             "apiVersion": "2019-06-01",
             "name": "[concat(variables('storageAccountName'), '/default')]",
@@ -87,7 +89,7 @@
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "sku": {
-                "name": "Standard_ZRS",
+                "name": "Standard_LRS",
                 "tier": "Standard"
             },
             "properties": {
@@ -102,10 +104,10 @@
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
             "apiVersion": "2019-06-01",
-            "name": "[concat(variables('storageAccountName'), '/default/customactivity')]",
+            "name": "[concat(variables('datalakeName'), '/default/customactivity')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('datalakeName'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('datalakeName'))]"
             ],
             "properties": {
                 "publicAccess": "None"
@@ -117,7 +119,7 @@
             "apiVersion": "2019-06-01",
             "location": "[variables('rgLocation')]",
             "tags": {
-            "HealthArchitestures": "FHIRToDEIDPipeline"
+                "HealthArchitestures": "FHIRToDEIDPipeline"
             },
             "kind": "StorageV2",
             "sku": {
@@ -247,7 +249,7 @@
             "name": "[variables('batchName')]",
             "location": "[variables('rgLocation')]",
             "tags": {
-            "HealthArchitestures": "FHIRToDEIDPipeline"
+                "HealthArchitestures": "FHIRToDEIDPipeline"
             },
             "properties": {
                 "poolAllocationMode": "BatchService",
@@ -261,7 +263,7 @@
             "type": "Microsoft.Batch/batchAccounts/pools",
             "apiVersion": "2020-03-01",
             "name": "[concat(variables('batchName'), '/', parameters('AzureBatch-poolName'))]",
-            
+
             "dependsOn": [
                 "[resourceId('Microsoft.Batch/batchAccounts', variables('batchName'))]"
             ],
@@ -295,7 +297,7 @@
                 }
             }
         }
-        
+
     ],
     "outputs": {}
 }

--- a/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part1.json
+++ b/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part1.json
@@ -53,7 +53,7 @@
             "name": "[variables('storageAccountName')]",
             "location": "[variables('rgLocation')]",
             "tags": {
-                "HealthArchitestures": "FHIRToDEIDPipeline"
+                "HealthArchitectures": "FHIRToDEIDPipeline"
             },
             "sku": {
                 "name": "Standard_LRS",
@@ -119,7 +119,7 @@
             "apiVersion": "2019-06-01",
             "location": "[variables('rgLocation')]",
             "tags": {
-                "HealthArchitestures": "FHIRToDEIDPipeline"
+                "HealthArchitectures": "FHIRToDEIDPipeline"
             },
             "kind": "StorageV2",
             "sku": {
@@ -249,7 +249,7 @@
             "name": "[variables('batchName')]",
             "location": "[variables('rgLocation')]",
             "tags": {
-                "HealthArchitestures": "FHIRToDEIDPipeline"
+                "HealthArchitectures": "FHIRToDEIDPipeline"
             },
             "properties": {
                 "poolAllocationMode": "BatchService",

--- a/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part2.json
+++ b/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part2.json
@@ -739,7 +739,7 @@
                             "referenceName": "AzureKeyVault",
                             "type": "LinkedServiceReference"
                         },
-                        "secretName": "datalakestring"
+                        "secretName": "blobstorageacctstring"
                     }
                 }
             },

--- a/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part2.json
+++ b/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part2.json
@@ -51,7 +51,7 @@
             "name": "[variables('logicAppName')]",
             "location": "[variables('rgLocation')]",
             "tags": {
-            "HealthArchitestures": "FHIRToDEIDPipeline"
+            "HealthArchitectures": "FHIRToDEIDPipeline"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.DataFactory/factories', variables('factoryName'))]"
@@ -338,6 +338,9 @@
             "type": "Microsoft.DataFactory/factories",
             "apiVersion": "2018-06-01",
             "location": "[variables('rgLocation')]",
+            "tags": {
+            "HealthArchitectures": "FHIRToDEIDPipeline"
+            },
             "identity": {
                 "type": "SystemAssigned"
             },

--- a/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part2.json
+++ b/Research-and-Analytics/FHIRExportwithAnonymization/Assets/arm_template_part2.json
@@ -739,7 +739,7 @@
                             "referenceName": "AzureKeyVault",
                             "type": "LinkedServiceReference"
                         },
-                        "secretName": "blobstorageacctstring"
+                        "secretName": "datalakestring"
                     }
                 }
             },

--- a/Research-and-Analytics/FHIRExportwithAnonymization/deployFHIRExportwithAnonymization.ps1
+++ b/Research-and-Analytics/FHIRExportwithAnonymization/deployFHIRExportwithAnonymization.ps1
@@ -65,7 +65,11 @@ the ARM templates.
 ### Key Value Name
 $KeyVaultName = $EnvironmentName + "kv"
     
-### Azure Storage Staging Account
+### Azure Batch Anynmization Code Storage Account
+$storageAccountName = $EnvironmentName + "dlg2"
+$storageAccountResourceGroup = $EnvironmentName
+
+<#
 if([string]::IsNullOrEmpty($IntegrationStorageAccount))
 {
     $storageAccountName = $EnvironmentName + "stg"
@@ -76,6 +80,7 @@ else {
     $storageAccountName = $IntegrationStorageAccount
     $storageAccountResourceGroup = $IntegrationStorageAccountResourceGroup
 }
+#>
 
 ### Logic App Name
 $logicAppName = $EnvironmentName + "la"
@@ -174,7 +179,7 @@ try
     $storageContext = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAcctKey.Value
     
     try {
-        Get-AzStorageContainer -Name "customactivity" -Context $storageContext    
+        Get-AzStorageContainer -Name "customactivity" -Context $storageContext
     }
     catch {
         New-AzStorageContainer -Name "customactivity" -Context $storageContext


### PR DESCRIPTION
- Moved the batch config to the data lake
- Made the staging blob storage account deployment conditional. If a FHIR Integration account is listed in the parameter settings then a blog storage account is not created
- Changed the staging blob account SKU from ZRS to LRS
- Adjusted the PowerShell to upload the batch config to the data lake
- Added PowerShell Az module min version number to the README
- Added posted deployment instructions for pre-configured FHIR Integration accounts.
- Cleared out legacy instructions
- Cleaned up titles for post deployment for added clarity.