### PR TITLE
Updated shebang of bash scripts for portability

### DIFF
--- a/FHIR/FHIRProxy/configmodules.bash
+++ b/FHIR/FHIRProxy/configmodules.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/FHIR/FHIRProxy/deployfhirproxy.bash
+++ b/FHIR/FHIRProxy/deployfhirproxy.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/HL7Conversion/deployhl72fhir.bash
+++ b/HL7Conversion/deployhl72fhir.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/HL7Conversion/deployhl7ingest.bash
+++ b/HL7Conversion/deployhl7ingest.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/HL7Conversion/runhl7relay.bash
+++ b/HL7Conversion/runhl7relay.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 


### PR DESCRIPTION
I found an issue while testing bash scripts in this repository on Mac OS. The shebang lines are currently not portable - it will execute bash only at `/bin/bash` instead of the location defined in PATH. This could cause issues on non-Linux systems or on systems with multiple versions of BASH installed.

This is an issue since most (if not all) Bash scripts use features only in Bash 4+ (for example `${VARNAME,,}`).

See [this link](https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html) for more details.

Fix is to change the shebang lines from `#!/bin/bash` to `#!/usr/bin/env bash`.