### PR TITLE
Fixed bug with hl72fhir script which only worked in eastus region

### DIFF
--- a/HL7Conversion/hl7tofhir/LogicAppCustomConnectors/fhir_converter_connect_template.json
+++ b/HL7Conversion/hl7tofhir/LogicAppCustomConnectors/fhir_converter_connect_template.json
@@ -17,7 +17,7 @@
             "type": "Microsoft.Web/customApis",
             "apiVersion": "2016-06-01",
             "name": "[parameters('customApis_HL7ConversionAPI_name')]",
-            "location": "eastus",
+            "location": "[resourceGroup().location]",
             "properties": {
                 "connectionParameters": {
                     "api_key": {

--- a/HL7Conversion/hl7tofhir/LogicAppCustomConnectors/fhir_server_connect_template.json
+++ b/HL7Conversion/hl7tofhir/LogicAppCustomConnectors/fhir_server_connect_template.json
@@ -17,7 +17,7 @@
             "type": "Microsoft.Web/customApis",
             "apiVersion": "2016-06-01",
             "name": "[parameters('customApis_FHIR_Server_Proxy_name')]",
-            "location": "eastus",
+            "location": "[resourceGroup().location]",
             "properties": {
                 "connectionParameters": {
                     "api_key": {

--- a/HL7Conversion/hl7tofhir/hl72fhir.json
+++ b/HL7Conversion/hl7tofhir/hl72fhir.json
@@ -71,44 +71,6 @@
         "description": "Azure Service Bus Queue Name"
       }
     },
-    "LogicAppLocation": {
-      "type": "string",
-      "minLength": 1,
-      "allowedValues": [
-        "[resourceGroup().location]",
-        "eastasia",
-        "southeastasia",
-        "centralus",
-        "eastus",
-        "eastus2",
-        "westus",
-        "northcentralus",
-        "southcentralus",
-        "northeurope",
-        "westeurope",
-        "japanwest",
-        "japaneast",
-        "brazilsouth",
-        "australiaeast",
-        "australiasoutheast",
-        "southindia",
-        "centralindia",
-        "westindia",
-        "canadacentral",
-        "canadaeast",
-        "uksouth",
-        "ukwest",
-        "westcentralus",
-        "westus2",
-        "koreacentral",
-        "koreasouth",
-        "francecentral",
-        "francesouth",
-        "southafricanorth",
-        "southafricawest"
-      ],
-      "defaultValue": "[resourceGroup().location]"
-    },
     "LogicAppName": {
       "type": "string",
       "minLength": 1,
@@ -218,7 +180,7 @@
                 "connectionName": "[parameters('HL7FHIRConverter_1_Connection_Name')]"
               },
               "azureblob": {
-                "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', 'eastus', '/managedApis/', 'azureblob')]",
+                "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/', 'azureblob')]",
                 "connectionId": "[resourceId('Microsoft.Web/connections', parameters('azureblob_1_Connection_Name'))]",
                 "connectionName": "[parameters('azureblob_1_Connection_Name')]"
               },
@@ -228,7 +190,7 @@
                 "connectionName": "[parameters('FHIRServerProxy_1_Connection_Name')]"
               },
               "servicebus": {
-                "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', 'eastus', '/managedApis/', 'servicebus')]",
+                "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/', 'servicebus')]",
                 "connectionId": "[resourceId('Microsoft.Web/connections', parameters('servicebus_1_Connection_Name'))]",
                 "connectionName": "[parameters('servicebus_1_Connection_Name')]"
               }
@@ -238,7 +200,7 @@
       },
       "name": "[parameters('LogicAppName')]",
       "type": "Microsoft.Logic/workflows",
-      "location": "[parameters('LogicAppLocation')]",
+      "location": "[resourceGroup().location]",
       "tags": {
         "displayName": "LogicApp"
       },
@@ -254,7 +216,7 @@
       "type": "MICROSOFT.WEB/CONNECTIONS",
       "apiVersion": "2018-07-01-preview",
       "name": "[parameters('HL7FHIRConverter_1_Connection_Name')]",
-      "location": "eastus",
+      "location": "[resourceGroup().location]",
       "properties": {
         "api": {
           "id": "[resourceId('Microsoft.Web/customApis', 'HL7FHIRConverter')]"
@@ -269,10 +231,10 @@
       "type": "MICROSOFT.WEB/CONNECTIONS",
       "apiVersion": "2018-07-01-preview",
       "name": "[parameters('azureblob_1_Connection_Name')]",
-      "location": "eastus",
+      "location": "[resourceGroup().location]",
       "properties": {
         "api": {
-          "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', 'eastus', '/managedApis/', 'azureblob')]"
+          "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/', 'azureblob')]"
         },
         "displayName": "[parameters('azureblob_1_Connection_DisplayName')]",
         "parameterValues": {
@@ -285,7 +247,7 @@
       "type": "MICROSOFT.WEB/CONNECTIONS",
       "apiVersion": "2018-07-01-preview",
       "name": "[parameters('FHIRServerProxy_1_Connection_Name')]",
-      "location": "eastus",
+      "location": "[resourceGroup().location]",
       "properties": {
         "api": {
           "id": "[resourceId('Microsoft.Web/customApis', 'FHIRServerProxy')]"
@@ -300,10 +262,10 @@
       "type": "MICROSOFT.WEB/CONNECTIONS",
       "apiVersion": "2018-07-01-preview",
       "name": "[parameters('servicebus_1_Connection_Name')]",
-      "location": "eastus",
+      "location": "[resourceGroup().location]",
       "properties": {
         "api": {
-          "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', 'eastus', '/managedApis/', 'servicebus')]"
+          "id": "[concat(subscription().id, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/', 'servicebus')]"
         },
         "displayName": "[parameters('servicebus_1_Connection_DisplayName')]",
         "parameterValues": {


### PR DESCRIPTION
The `HL7Conversion/deployhl72fhir.bash` script has a bug where the `eastus` region is hardcoded in some ARM templates. This fix changes the ARM templates called in this script to simply deploy the resources in the same region of the resource group to avoid this issue - where a connection is referenced in a different region.

The issue with the current templates was encountered when I attempted to deploy to `westus2` and got the following error:
![image](https://user-images.githubusercontent.com/753437/95671794-b613b980-0b4f-11eb-8632-581a705e5791.png)

I removed the changing of the Logic App location in relation to the resource group because it's not caused by the script and it could cause the confusing error if someone tries to mismatch the two settings.