### PR TITLE
GeoPolitical Fix - Remove Exclude

### DIFF
--- a/GeoPol.xml
+++ b/GeoPol.xml
@@ -17,7 +17,6 @@
     <Component Exclude="List exceptions here to not be scanned, that have been included above">    
     <!-- Make sure to consult http://aka.ms/NExtStart if excluding 3rd party or OSS components -->
     <!-- Use back slash \ to indicate folder path e.g. src\external\ -->
-    <ExcludeFolder>FHIR\FHIRProxy\distribution\publish.zip\specification.zip\dataelements.xml</ExcludeFolder>
     <ExcludeFolder>FHIR\FHIRProxy\distribution\publish.zip\specification.zip\extension-definitions.xml</ExcludeFolder>
     <ExcludeFolder>FHIR\FHIRProxy\distribution\publish.zip\specification.zip\profiles-others.xml</ExcludeFolder>
     <ExcludeFolder>FHIR\FHIRProxy\distribution\publish.zip\specification.zip\profiles-resources.xml</ExcludeFolder>


### PR DESCRIPTION
File FHIR\FHIRProxy\distribution\publish.zip\specification.zip\dataelements.xml no longer exists so cannot explicitly exclude it.
Removing from exclude list.